### PR TITLE
Add workflow to scrape GA DPH Chart data

### DIFF
--- a/.github/workflows/GDPH-daily-chart-scrape.yml
+++ b/.github/workflows/GDPH-daily-chart-scrape.yml
@@ -1,0 +1,23 @@
+name: gdph-daily-charts
+
+on:
+  schedule:
+    - cron: '03  1 * * *' # hours are UTC (UTC hour = EST hour +4) 
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+     - uses: actions/checkout@v2
+     - uses: e3bo/ga-dph-covid-chart-scraper@v0.3
+     - name: Commit and push output files
+       shell: bash
+       run: |
+         git pull
+         mv dash.html GA-DPH-CanvasJS-data-cases-deaths.csv georgia/ga_GDPH_daily_status_report
+         git add georgia/ga_GDPH_daily_status_report
+         git config --local user.email "actions@users.noreply.github.com"
+         git config --local user.name "Automated Publisher"
+         git commit -m "gdph-daily-charts Autoupdate"
+         git push
+       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,6 +4,8 @@
 
 **GDPH-daily-status-scrape.yml**: Runs at 12:00 EST (16:00 UTC) and 19:00 EST (23:00 EST) daily. Runs `georgia/ga_GDPH_daily_status_report/read_GDPH_daily_status_report.R`
 
+**GDPH-daily-chart-scrape.yml**: Runs at 9:03 EST (1:03 UTC) daily. Uses Github Action in https://github.com/e3bo/ga-dph-covid-chart-scraper
+
 **github-update.yml**: Runs at 8:00 EST (12:00 UTC). Runs `github_data_update.R`
 
 **us-cases-wiki-scrape.yml**: Runs at 6:00 (10:00 UTC) and 22:00 (2:00 UTC) daily. Runs `US/US_wikipedia_cases_fatalities/read_UScases_wikipedia.R`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 
+![gdph-daily-charts](https://github.com/e3bo/COVID-19-DATA/workflows/gdph-daily-charts/badge.svg)
+
 Repository that stores datasets used in different COVID CEID projects.
 =======
 The datasets in the repository were compiled by members of the CEID COVID-19 working group. The data at the top level of the repository have been formated to be used 'as-is' and are updated often. Data sets were either created from html scraping or manually entered. In the case of the automated web scraping, the raw data and scripts are organized into sub-directories. The description of each data file along with the corresponding sub-directories are listed below. The metadata is in the readme of the same directory as the data.

--- a/georgia/ga_GDPH_daily_status_report/README.md
+++ b/georgia/ga_GDPH_daily_status_report/README.md
@@ -75,3 +75,20 @@ Reads from the Georgia Department of Public Health website, information about nu
 
 <b>Projects</b>
 - TBD
+
+
+## dash.html
+
+Latest daily download of the GA DPH dashboard HTML
+
+## GA-DPH-CanvasJS-data-cases-deaths.csv
+
+Reads from CanvasJS chart data in dash.html
+
+Metadata:
+ Column name descript of data file:
+- `date` - date of count
+- `cumulative_cases` - cumulative number of covid cases' symptom onset or lab diagnosis
+- `cumulative_deaths` - cumulative number of deaths
+- `dph_report_generation_time` - timestamp on webpage of report generation
+- `dashboard_md5sum` - md5 checksum of the dash.html file used to obtain the data


### PR DESCRIPTION
The chart data appears to be more accurate than what one finds in covidtracking.com etc, because such sites only collect the most recent cumulative numbers each day from the website, whereas the chart data is the best known complete time series for each day. So I added a scraper which puts this data into a CSV file and a workflow to run it daily.